### PR TITLE
item.id.hashCode can generate negative values when the id is beyond 1…

### DIFF
--- a/hnswlib-spark/src/main/scala/com/github/jelmerk/knn/spark/KnnAlgorithm.scala
+++ b/hnswlib-spark/src/main/scala/com/github/jelmerk/knn/spark/KnnAlgorithm.scala
@@ -2,6 +2,7 @@ package com.github.jelmerk.knn.spark
 
 import java.net.InetAddress
 
+import scala.math.abs
 import org.apache.spark.ml.{Estimator, Model}
 import org.apache.spark.ml.linalg.Vector
 import org.apache.spark.ml.param._
@@ -236,7 +237,7 @@ abstract class KnnAlgorithm[TModel <: Model[TModel]](override val uid: String) e
 
     val indicesRdd = dataset.select(col(getIdentifierCol).cast(StringType).as("id"),
       vectorCol.as("vector")).as[IndexItem]
-      .map { item => (item.id.hashCode % getNumPartitions, item) }
+      .map { item => (abs(item.id.hashCode) % getNumPartitions, item) }
       .rdd
       .partitionBy(partitioner)
       .mapPartitions( it =>

--- a/hnswlib-spark/src/test/scala/com/github/jelmerk/knn/spark/hnsw/HnswSpec.scala
+++ b/hnswlib-spark/src/test/scala/com/github/jelmerk/knn/spark/hnsw/HnswSpec.scala
@@ -26,9 +26,9 @@ class HnswSpec extends FunSuite with DatasetSuiteBase {
     import sqlCtx.implicits._
 
     val input = sc.parallelize(Seq(
-      VectorInputRow(1, Vectors.dense(0.0110f, 0.2341f)),
-      VectorInputRow(2, Vectors.dense(0.2300f, 0.3891f)),
-      VectorInputRow(3, Vectors.dense(0.4300f, 0.9891f))
+      VectorInputRow(1000000, Vectors.dense(0.0110f, 0.2341f)),
+      VectorInputRow(2000000, Vectors.dense(0.2300f, 0.3891f)),
+      VectorInputRow(3000000, Vectors.dense(0.4300f, 0.9891f))
     )).toDS
 
     val hnsw = new Hnsw()
@@ -44,9 +44,9 @@ class HnswSpec extends FunSuite with DatasetSuiteBase {
       .collect()
 
     result should have size 3
-    result should contain(VectorOutputRow(2, Seq(VectorOutputRowNeighbor(3, 0.0076490045f), VectorOutputRowNeighbor(1, 0.11621308f))))
-    result should contain(VectorOutputRow(3, Seq(VectorOutputRowNeighbor(2, 0.0076490045f), VectorOutputRowNeighbor(1, 0.06521261f))))
-    result should contain(VectorOutputRow(1, Seq(VectorOutputRowNeighbor(3, 0.06521261f), VectorOutputRowNeighbor(2, 0.11621308f))))
+    result should contain(VectorOutputRow(2000000, Seq(VectorOutputRowNeighbor(3000000, 0.0076490045f), VectorOutputRowNeighbor(1000000, 0.11621308f))))
+    result should contain(VectorOutputRow(3000000, Seq(VectorOutputRowNeighbor(2000000, 0.0076490045f), VectorOutputRowNeighbor(1000000, 0.06521261f))))
+    result should contain(VectorOutputRow(1000000, Seq(VectorOutputRowNeighbor(3000000, 0.06521261f), VectorOutputRowNeighbor(2000000, 0.11621308f))))
   }
 
   test("array input row float") {


### PR DESCRIPTION
item.id.hashCode can generate negative values when the id is beyond 1,700,000, which causes the error. 

To fix the bug, we add abs to it: 
abs(item.id.hashCode).