### PR TITLE
init level connections under the control of maxM0 and maxM

### DIFF
--- a/hnswlib-core/src/main/java/com/github/jelmerk/knn/hnsw/HnswIndex.java
+++ b/hnswlib-core/src/main/java/com/github/jelmerk/knn/hnsw/HnswIndex.java
@@ -212,7 +212,7 @@ public class HnswIndex<TId, TVector, TItem extends Item<TId, TVector>, TDistance
         IntArrayList[] connections = new IntArrayList[randomLevel + 1];
 
         for (int level = 0; level <= randomLevel; level++) {
-            int levelM = randomLevel == 0 ? maxM0 : maxM;
+            int levelM = level == 0 ? maxM0 : maxM;
             connections[level] = new IntArrayList(levelM);
         }
 


### PR DESCRIPTION
At line 215 of `HnswIndex.java`,  `randomLevel==0` may not meet expectations, which will reault in `maxM0` not working.

```
        for (int level = 0; level <= randomLevel; level++) {
            int levelM = level == 0 ? maxM0 : maxM;
            connections[level] = new IntArrayList(levelM);
        }
```